### PR TITLE
Stop capitalizing title

### DIFF
--- a/lib/pr_log/formatter.rb
+++ b/lib/pr_log/formatter.rb
@@ -29,7 +29,7 @@ module PrLog
     end
 
     def format_title(pull_request)
-      pull_request[:title].capitalize
+      pull_request[:title]
     end
   end
 end

--- a/spec/pr_log/formatter_spec.rb
+++ b/spec/pr_log/formatter_spec.rb
@@ -33,20 +33,6 @@ module PrLog
         TEXT
       end
 
-      it 'turns title into lower case sentence' do
-        data = [{ title: 'Some Capitalized Title',
-                  number: 1 }]
-        template = "- %{title} (#%{number})\n"
-        formatter = Formatter.new(data, template, {})
-
-        result = formatter.entries
-
-        expect(result).to eq(<<-TEXT.unindent)
-
-          - Some capitalized title (#1)
-        TEXT
-      end
-
       it 'returns empty string if no pull requests are passed' do
         template = "- %{title} (#%{number})\n"
         formatter = Formatter.new([], template, {})


### PR DESCRIPTION
closes https://github.com/tf/pr_log/issues/4
also updates rubocop because its version on houndci is newer and makes tests fail..