### PR TITLE
Add support for nested fields in `entry_template`

### DIFF
--- a/README.md
+++ b/README.md
@@ -126,6 +126,7 @@ with the label `bug`, add the following lines to your configuration file:
 After checking out the repo, run `bin/setup` to install
 dependencies. You can also run `bin/console` for an interactive prompt
 that will allow you to experiment.
+You can then use `rake install` to install the gem locally.
 
 ### Running the Test Suite
 

--- a/README.md
+++ b/README.md
@@ -93,6 +93,7 @@ The following configuration options are available:
   entries. All fields from the
   [issue search response](https://developer.github.com/v3/search/#search-issues)
   can be used as interpolations.
+  Default value: `- %{title} ([#%{number}](%{html_url}))`. Use `.` for nested fields (e.g. `%{user.login}`).
 
 - `github_repository`: Name of the GitHub repository of the form
   `user/repository`.

--- a/lib/pr_log/formatter.rb
+++ b/lib/pr_log/formatter.rb
@@ -33,3 +33,24 @@ module PrLog
     end
   end
 end
+
+class String
+  alias old_interpolation %
+  def %(x)
+    if x.is_a? Hash
+      self.scan(/(?<=%{)[^}]*(?=})/).inject(self) do |result, match|
+        keys = match.split('.').map(&:to_sym)
+        begin
+          value = x.dig(*keys)
+        rescue => error
+          # what should do here ?
+        ensure
+          result = result.sub(/%{[^}]*}/, value.to_s)
+        end
+        result
+      end
+    else
+      old_interpolation x
+    end
+  end
+end

--- a/spec/pr_log/formatter_spec.rb
+++ b/spec/pr_log/formatter_spec.rb
@@ -18,6 +18,21 @@ module PrLog
         TEXT
       end
 
+      it 'interpolates entry templates with pull request data and user data' do
+        data = [{ title: 'Feature 1', number: 1, user: { login: 'l0g1n' } },
+                { title: 'Feature 2', number: 2, user: { login: 'Nick3C' } }]
+        template = "- %{title} (#%{number}) by %{user.login}\n"
+        formatter = Formatter.new(data, template, {})
+
+        result = formatter.entries
+
+        expect(result).to eq(<<-TEXT.unindent)
+
+          - Feature 1 (#1) by l0g1n
+          - Feature 2 (#2) by Nick3C
+        TEXT
+      end
+
       it 'interpolates prefixes based on pull request labels' do
         data = [{ title: 'Some fix',
                   number: 1,


### PR DESCRIPTION
- This allows for templates such as `"- %{title} (#%{number}) by %{user.login}\n"`
- Also, better document the `entry_template` setting to give an example of the expected format

Fixes https://github.com/tf/pr_log/issues/10