### PR TITLE
Fix deprecation warnings in specs

### DIFF
--- a/pr_log.gemspec
+++ b/pr_log.gemspec
@@ -19,11 +19,11 @@ Gem::Specification.new do |spec|
   spec.executables = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ['lib']
 
-  spec.add_dependency 'attr_extras', '~> 4.4'
+  spec.add_dependency 'attr_extras', '~> 7.0'
   spec.add_dependency 'events', '~> 0.9.8'
   spec.add_dependency 'faraday', '~> 1'
   spec.add_dependency 'octokit', '~> 4.0'
-  spec.add_dependency 'thor', '~> 0.19'
+  spec.add_dependency 'thor', '~> 1.3'
   spec.add_dependency 'virtus', '~> 1.0'
 
   spec.add_development_dependency 'bundler', ['>= 1.10', '< 3']


### PR DESCRIPTION
## Summary
- use modern attr_extras
- update Thor dependency

## Testing
- `bundle exec bin/rspec`

------
https://chatgpt.com/codex/tasks/task_b_684ff47223a08324883f33eead75257b